### PR TITLE
simple command line for model dsl descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,76 @@ The library tries to abstract and simplify the definition of models and their in
 Please note that while this can already serve as one of the reference implementations for VODML, from a production
 standpoint this project is still work in progress.
 
+## Modeling How-To
+**NOTE**: This is still pretty much Work-In-Progress. Help is appreciated, also if it's in the form
+of an issue report.
+
+### Requirements
+In order to build Jovial Maven 3 and Java SDK 7 or 8 are required.
+
+### Build
+
+To build the *jar* file:
+
+```
+$ mvn package
+```
+
+The above command will also run all the units and integration tests.
+
+A very simple command line interface allows users to provide an input file with a DSL description of the
+model and get the equivalent VODML-XML file printed to the standard output, e.g.
+
+```
+$ cat test.vodml
+import org.joda.time.DateTime
+
+model("myModel") {
+    author "John Doe"
+    title "My Model"
+    lastModified DateTime.now().toString()
+    pack "myPackage", {
+        dataType "myDataType", {
+            attribute "anAttribute", description: "A description", dataType: ivoa.string
+        }
+    }
+}
+
+$ java -jar target/jovial-1.0-SNAPSHOT-jar-with-dependencies.jar test.vodml
+<?xml version="1.0" encoding="UTF-8"?><vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VODML/v1.0 http://volute.g-vo.org/svn/trunk/projects/dm/vo-dml/xsd/vo-dml-v1.0.xsd">
+  <name>myModel</name>
+  <description/>
+  <title>My Model</title>
+  <author>John Doe</author>
+  <version>1.0</version>
+  <lastModified>2016-10-28T09:55:11.106-04:00</lastModified>
+  <package>
+    <vodml-id>myPackage</vodml-id>
+    <name>myPackage</name>
+    <description/>
+    <dataType>
+      <vodml-id>myPackage.myDataType</vodml-id>
+      <name>myDataType</name>
+      <description/>
+      <attribute>
+        <vodml-id>myPackage.myDataType.anAttribute</vodml-id>
+        <name>anAttribute</name>
+        <description>A description</description>
+        <datatype>
+          <vodml-ref>ivoa:string</vodml-ref>
+        </datatype>
+        <multiplicity>
+          <minOccurs>1</minOccurs>
+          <maxOccurs>1</maxOccurs>
+        </multiplicity>
+      </attribute>
+    </dataType>
+  </package>
+</vo-dml:model>
+```
+
+The above code also shows how to include arbitrary code to generate content.
+
 ## Examples
 The following Groovy code convert a DSL description of a simple data model into its standardized VODML/XML description.
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
-            <version>1.6</version>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>2.2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -115,6 +115,35 @@
                     <source>1.7</source>
                     <target>1.7</target>
                 </configuration>
+            </plugin>
+            <!-- Maven Assembly Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.2.1</version>
+                <configuration>
+                    <!-- get all project dependencies -->
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <!-- MainClass in mainfest make a executable jar -->
+                    <archive>
+                        <manifest>
+                            <mainClass>cfa.vo.vodml.io.Main</mainClass>
+                        </manifest>
+                    </archive>
+
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <!-- bind to the packaging phase -->
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>

--- a/src/main/groovy/cfa/vo/vodml/io/Main.groovy
+++ b/src/main/groovy/cfa/vo/vodml/io/Main.groovy
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * jovial
+ * %%
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Smithsonian Astrophysical Observatory nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package cfa.vo.vodml.io
+
+public class Main {
+    public static void main(String[] args) {
+        def modelString = new File(args[0]).text
+        def builder = new ModelBuilder()
+        def binding = new Binding(model: builder.&script)
+        def shell = new GroovyShell(Main.class.classLoader, binding)
+        def model = shell.evaluate modelString
+        def writer = new VodmlWriter()
+        writer.write(model, System.out)
+    }
+}

--- a/src/main/groovy/cfa/vo/vodml/io/ModelBuilder.groovy
+++ b/src/main/groovy/cfa/vo/vodml/io/ModelBuilder.groovy
@@ -91,4 +91,8 @@ class ModelBuilder extends FactoryBuilderSupport {
             new VodmlRef(name, "")
         }
     }
+
+    def script = { lhm, cl ->
+        this.model(lhm, cl)
+    }
 }

--- a/src/test/groovy/cfa/vo/vodml/MetaModelTest.groovy
+++ b/src/test/groovy/cfa/vo/vodml/MetaModelTest.groovy
@@ -5,8 +5,7 @@ import ca.odell.glazedlists.EventList
 import cfa.vo.vodml.io.Validator
 import cfa.vo.vodml.io.VodmlWriter
 import cfa.vo.vodml.metamodel.*
-import org.custommonkey.xmlunit.XMLAssert
-import org.custommonkey.xmlunit.XMLUnit
+import cfa.vo.vodml.utils.XmlUtils
 import org.joda.time.DateTime
 import org.junit.Test
 
@@ -54,13 +53,11 @@ class MetaModelTest {
         ByteArrayOutputStream os = new ByteArrayOutputStream()
         writer.write(model, os)
         String out = os.toString("UTF-8")
-        XMLAssert.assertXMLEqual(expected, out)
+        XmlUtils.testXml(expected, out)
         assert new Validator().validate(new ByteArrayInputStream(out.bytes))
     }
 
     String setUpModel() {
-        XMLUnit.ignoreWhitespace = true
-
         ObjectType role = new ObjectType(
                 name: "Role",
                 vodmlid: "party.Role",

--- a/src/test/groovy/cfa/vo/vodml/io/MainTest.groovy
+++ b/src/test/groovy/cfa/vo/vodml/io/MainTest.groovy
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * jovial
+ * %%
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Smithsonian Astrophysical Observatory nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package cfa.vo.vodml.io
+
+import cfa.vo.vodml.utils.XmlUtils
+import spock.lang.Specification
+
+
+class MainTest extends Specification {
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream()
+    private final PrintStream stdout = System.out
+
+    def setup() {
+        System.setOut(new PrintStream(outContent))
+    }
+
+    def cleanup() {
+        System.setOut(stdout)
+    }
+
+    def "test main"() {
+        given: "test arguments"
+        def tempFile = File.createTempFile("test", "dsl")
+        tempFile.write("model('testModel'){}")
+        String[] args = [tempFile.absolutePath,]
+        when: "main is called"
+        Main.main(args)
+        then: "a model is printed to standard output"
+        assert XmlUtils.testXml(basicModel, outContent.toString())
+    }
+
+    def basicModel = """<?xml version="1.0" encoding="UTF-8"?>
+<vo-dml:model xmlns:vo-dml="http://www.ivoa.net/xml/VODML/v1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.ivoa.net/xml/VODML/v1.0 http://volute.g-vo.org/svn/trunk/projects/dm/vo-dml/xsd/vo-dml-v1.0.xsd">
+<name>testModel</name>
+<description/>
+<title>My Model</title>
+<version>1.0</version>
+<lastModified>2016-10-27T16:44:47.097-04:00</lastModified>
+</vo-dml:model>
+"""
+}

--- a/src/test/groovy/cfa/vo/vodml/io/ModelBuilderTest.groovy
+++ b/src/test/groovy/cfa/vo/vodml/io/ModelBuilderTest.groovy
@@ -38,7 +38,6 @@ import cfa.vo.vodml.metamodel.ElementRef
 import cfa.vo.vodml.metamodel.Model
 import cfa.vo.vodml.metamodel.Multiplicity
 import cfa.vo.vodml.utils.VodmlRef
-import org.custommonkey.xmlunit.XMLUnit
 import spock.lang.Specification
 
 class ModelBuilderTest extends Specification {
@@ -403,7 +402,6 @@ Illegal multiplicity expression. Please use '<minOccurs>..<maxOccurs>', where:
         given: "I/O infrastructure"
         def writer = new VodmlWriter()
         def os = new ByteArrayOutputStream()
-        XMLUnit.ignoreWhitespace = true
         and: "full model"
         Model model = builder.model("ds") {
             title("Dataset Metadata")

--- a/src/test/groovy/cfa/vo/vodml/io/VoTableBuilderTest.groovy
+++ b/src/test/groovy/cfa/vo/vodml/io/VoTableBuilderTest.groovy
@@ -6,18 +6,18 @@
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- *
+ * 
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * 3. Neither the name of the Smithsonian Astrophysical Observatory nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -37,8 +37,7 @@ import cfa.vo.vodml.instance.ModelInstance
 import cfa.vo.vodml.instance.ObjectInstance
 import cfa.vo.vodml.instance.ValueInstance
 import cfa.vo.vodml.instance.VotableInstance
-import org.custommonkey.xmlunit.XMLAssert
-import org.custommonkey.xmlunit.XMLUnit
+import cfa.vo.vodml.utils.XmlUtils
 import org.junit.Before
 import org.junit.Test
 
@@ -55,8 +54,6 @@ class VoTableBuilderTest {
 
     @Before
     void setUp() {
-        XMLUnit.setIgnoreWhitespace(true);
-        XMLUnit.setIgnoreComments(true);
         def reader = new VodmlReader()
         dsSpec = reader.read(getClass().getResource("/DatasetMetadata-1.0.vo-dml.xml").openStream())
         ivoaSpec = reader.read(getClass().getResource("/ivoa.vo-dml.xml").openStream())
@@ -75,7 +72,7 @@ class VoTableBuilderTest {
         instance.toXml(os)
         String actual = os.toString("UTF-8")
         String expected = preamble("")
-        XMLAssert.assertXMLEqual(expected, actual)
+        XmlUtils.testXml(expected, actual)
     }
 
     @Test

--- a/src/test/java/cfa/vo/vodml/io/VodmlWriterTest.java
+++ b/src/test/java/cfa/vo/vodml/io/VodmlWriterTest.java
@@ -1,5 +1,3 @@
-package cfa.vo.vodml.io;
-
 /*
  * #%L
  * jovial
@@ -32,11 +30,10 @@ package cfa.vo.vodml.io;
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-
+package cfa.vo.vodml.io;
 
 import cfa.vo.vodml.metamodel.Model;
-import org.custommonkey.xmlunit.XMLAssert;
-import org.custommonkey.xmlunit.XMLUnit;
+import cfa.vo.vodml.utils.XmlUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -61,8 +58,6 @@ public class VodmlWriterTest {
 
         writer = new VodmlWriter();
         expected = makeString();
-
-        XMLUnit.setIgnoreWhitespace(true);
     }
 
     @Test
@@ -70,18 +65,18 @@ public class VodmlWriterTest {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         writer.write(model, os);
         String out = os.toString("UTF-8");
-        XMLAssert.assertXMLEqual(expected, out);
+        XmlUtils.testXml(expected, out);
     }
 
     private String makeString() {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "  <vo-dml:model xmlns:vo-dml=\"http://www.ivoa.net/xml/VODML/v1.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.ivoa.net/xml/VODML/v1.0 http://volute.g-vo.org/svn/trunk/projects/dm/vo-dml/xsd/vo-dml-v1.0.xsd\">\n" +
                 "    <name>something</name>\n" +
+                "    <description>Some Description</description>\n" +
                 "    <title>Some Title</title>\n" +
+                "    <author>John Doe</author>\n" +
                 "    <version>1.0-SNAPSHOT</version>\n" +
                 "    <lastModified>2016-04-16T10:16:50.000Z</lastModified>\n" +
-                "    <author>John Doe</author>\n" +
-                "    <description>Some Description</description>\n" +
                 "  </vo-dml:model>";
     }
 }

--- a/src/test/java/cfa/vo/vodml/utils/XmlUtils.java
+++ b/src/test/java/cfa/vo/vodml/utils/XmlUtils.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * jovial
+ * %%
+ * Copyright (C) 2016 Smithsonian Astrophysical Observatory
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the Smithsonian Astrophysical Observatory nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package cfa.vo.vodml.utils;
+
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.util.Predicate;
+
+public class XmlUtils {
+
+    public static boolean testXml(String control, String actual) {
+        Diff diff = baseBuilder(control, actual).build();
+        return doTest(diff);
+    }
+
+    private static boolean doTest(Diff diff) {
+        if (diff.hasDifferences()) {
+            throw new AssertionError(diff.toString());
+        }
+        return true;
+    }
+
+    private static DiffBuilder baseBuilder(String control, String actual) {
+        return DiffBuilder.compare(control)
+                .withTest(actual)
+                .checkForSimilar()
+                .ignoreWhitespace()
+                .ignoreComments()
+                .withNodeFilter(new Predicate<org.w3c.dom.Node>(){
+                    @Override
+                    public boolean test(org.w3c.dom.Node node) {
+                        return !"lastModified".equals(node.getNodeName());
+                    }
+                })
+                .normalizeWhitespace();
+    }
+}


### PR DESCRIPTION
This PR introduces a rather simple CLI for generating VODML XML descriptors from Domain Specific Language descriptions.

Not much error handling for now, and I have a prototype that would make it possible to get some IDE support in IntelliJ IDEA, but I am currently on vacation, so bells and whistles will have to wait.

To test the code, assuming the code has been cloned already:

```
$ git fetch
$ git checkout model-ui
$ mvn package
```
