### PR TITLE
update and fix travis and appveyor config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode7
-    - os: osx
-      osx_image: beta-xcode6.3
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,14 @@ install:
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
+          'http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
 
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
-  - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.3.9
+  - cmd: SET PATH=C:\maven\apache-maven-3.3.9\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
 
@@ -23,5 +23,4 @@ test_script:
   - mvn clean install --batch-mode
 
 cache:
-  - C:\maven\
   - C:\Users\appveyor\.m2


### PR DESCRIPTION
This PR removes an obsolete osx version, updates maven in the appveyor configuration, and removes the maven binaries cache, which was apparently breaking the build.